### PR TITLE
Add Node 14 support with dual CJS/ESM builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,38 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [20, 22, 24]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 24
           cache: 'npm'
       - run: npm ci
       - run: npm run build
       - run: npm test
       - run: npm run lint
       - run: npm run format:check
+      - run: npm pack
+      - uses: actions/upload-artifact@v4
+        with:
+          name: package
+          path: "*.tgz"
+
+  test-package:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [14, 16, 18, 20, 22, 24]
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: package
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm install *.tgz
+      - name: Test ESM import
+        run: node --eval "import('recoil-tdf').then(m => { const r = m.parse('[s]{k=v;}'); if (r.s.k === 'v') console.log('ESM OK'); else process.exit(1); })"
+      - name: Test CJS require
+        run: node --eval "const m = require('recoil-tdf'); const r = m.parse('[s]{k=v;}'); if (r.s.k === 'v') console.log('CJS OK'); else process.exit(1);"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,14 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [20, 22, 24]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ matrix.node }}
           cache: 'npm'
       - run: npm ci
       - run: npm run build
@@ -15,10 +18,12 @@ jobs:
       - run: npm run lint
       - run: npm run format:check
       - run: npm pack
+        if: matrix.node == 24
       - uses: actions/upload-artifact@v4
+        if: matrix.node == 24
         with:
           name: package
-          path: "*.tgz"
+          path: '*.tgz'
 
   test-package:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - run: npm run format:check
       - run: npm pack
         if: matrix.node == 24
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: matrix.node == 24
         with:
           name: package
@@ -32,7 +32,7 @@ jobs:
       matrix:
         node: [14, 16, 18, 20, 22, 24]
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: package
       - uses: actions/setup-node@v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^9.39.2",
-        "@tsconfig/node16": "^16.1.1",
+        "@tsconfig/node14": "^14.1.2",
         "@tsconfig/strictest": "^2.0.2",
         "@types/node": "^20.11.16",
         "eslint": "^9.39.2",
@@ -22,7 +22,7 @@
         "wasmoon-lua5.1": "~1.17.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -221,10 +221,10 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@tsconfig/node16": {
-      "version": "16.1.8",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.8.tgz",
-      "integrity": "sha512-T/CfdwFry660WjZor56z0F3pxeCllt8KOxWcHFW6ZEuULKUObTDEMdgtctyuJPxwqyWDsvHRfxHaJ4FIICyoqQ==",
+    "node_modules/@tsconfig/node14": {
+      "version": "14.1.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-14.1.8.tgz",
+      "integrity": "sha512-SjGT+qPvh8Uhc849yNMD0ZIPr69AyB7Z46nMqhrI3gCVocd6mhI0jP4YE4onO/ufpmengRfTxNMpdpKEp2xRIg==",
       "dev": true,
       "license": "MIT"
     },
@@ -311,7 +311,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -529,7 +528,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -763,7 +761,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1348,7 +1345,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1563,7 +1559,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "scripts": {
     "gen-parser": "tspeg --include-grammar-comment=false src/tdf.peg src/tdf.peg.ts",
-    "build": "npm run gen-parser && tsc -p tsconfig.json && tsc -p tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
-    "test": "npm run gen-parser && tsc -p tsconfig.json --noCheck && node --test dist/esm/index.test.js",
+    "build": "npm run gen-parser && tsc && tsc -p tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
+    "test": "npm run gen-parser && tsc --noCheck && node --test dist/esm/index.test.js",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "gen-parser": "tspeg --include-grammar-comment=false src/tdf.peg src/tdf.peg.ts",
     "build": "npm run gen-parser && tsc -p tsconfig.json && tsc -p tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
-    "test": "npm run gen-parser && tsc -p tsconfig.test.json --noCheck && node --test dist/esm/index.test.js",
+    "test": "npm run gen-parser && tsc -p tsconfig.json --noCheck && node --test dist/esm/index.test.js",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -10,27 +10,39 @@
   },
   "scripts": {
     "gen-parser": "tspeg --include-grammar-comment=false src/tdf.peg src/tdf.peg.ts",
-    "build": "npm run gen-parser && tsc",
-    "test": "npm run gen-parser && tsc --noCheck && node --test dist/index.test.js",
+    "build": "npm run gen-parser && tsc -p tsconfig.json && tsc -p tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
+    "test": "npm run gen-parser && tsc -p tsconfig.test.json --noCheck && node --test dist/esm/index.test.js",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },
   "type": "module",
-  "exports": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    }
+  },
+  "main": "./dist/cjs/index.js",
+  "types": "./dist/esm/index.d.ts",
   "sideEffects": false,
   "files": [
     "/dist",
-    "!/dist/*.test.*"
+    "!/dist/**/*.test.*"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=14"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
-    "@tsconfig/node16": "^16.1.1",
+    "@tsconfig/node14": "^14.1.2",
     "@tsconfig/strictest": "^2.0.2",
     "@types/node": "^20.11.16",
     "eslint": "^9.39.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
       }
     }
   },
-  "main": "./dist/cjs/index.js",
   "types": "./dist/esm/index.d.ts",
   "sideEffects": false,
   "files": [

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -2,11 +2,11 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": ["@tsconfig/node14/tsconfig.json", "@tsconfig/strictest/tsconfig.json"],
   "compilerOptions": {
-    "outDir": "dist/esm",
+    "outDir": "dist/cjs",
     "declaration": true,
     "noUnusedParameters": false,
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext"
+    "module": "CommonJS",
+    "moduleResolution": "Node"
   },
   "include": ["src/**/*"],
   "exclude": ["src/**/*.test.ts"]

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": ["@tsconfig/node14/tsconfig.json", "@tsconfig/strictest/tsconfig.json"],
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "declaration": true,
-    "noUnusedParameters": false,
     "module": "CommonJS",
     "moduleResolution": "Node"
   },
-  "include": ["src/**/*"],
   "exclude": ["src/**/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,7 @@
   "compilerOptions": {
     "outDir": "dist/esm",
     "declaration": true,
-    "noUnusedParameters": false,
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext"
+    "noUnusedParameters": false
   },
   "include": ["src/**/*"],
   "exclude": ["src/**/*.test.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,5 @@
     "declaration": true,
     "noUnusedParameters": false
   },
-  "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src/**/*"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "./tsconfig.json",
-  "include": ["src/**/*"],
-  "exclude": []
-}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,10 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext"
-  },
   "include": ["src/**/*"],
   "exclude": []
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  },
+  "include": ["src/**/*"],
+  "exclude": []
+}


### PR DESCRIPTION
- Add dual CJS/ESM builds with Node 14+ support
- ESM → dist/esm/, CJS → dist/cjs/
- CI tests package imports (ESM + CJS) across Node 14-24

https://claude.ai/code/session_01PFDXZWR5R6T8283sRS7Eae